### PR TITLE
Update README.md (Fix link to Case Sensitivity Documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can set the following global properties using static methods on the `Files` 
 
 #### Comparing Case insensitive files and paths
 
-For related documentation see [Case Sensitivity Documentation](https://www.files.com/docs/topics/file-system-semantics#case-sensitivity).
+For related documentation see [Case Sensitivity Documentation](https://www.files.com/docs/files-and-folders/file-system-semantics#case-sensitivity).
 
     import { pathNormalizer } from 'files.com/lib/utils.js'
 


### PR DESCRIPTION
I noticed the link to "Case Sensitivity Documentation" redirected to docs main page instead of going directly to the appropriate section, likely because it became outdated. 